### PR TITLE
feat: implement operator-level queue control APIs

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,6 +2,7 @@ import express from "express";
 import healthRouter from "./routes/health.js";
 import router from "./routes/index.js";
 import queueRouter from "./modules/queue/queue.routes.js";
+import operatorRouter from "./modules/operator/operator.routes.js";
 
 const app = express();
 
@@ -12,6 +13,8 @@ app.use(express.json());
 app.use("/health", healthRouter);
 // Queue API endpoints
 app.use("/api/queues", queueRouter);
+// Operator API endpoints
+app.use("/api/operator", operatorRouter);
 
 // Main routes
 app.use("/", router);

--- a/backend/src/modules/operator/operator.controller.ts
+++ b/backend/src/modules/operator/operator.controller.ts
@@ -1,0 +1,67 @@
+import { Request, Response } from "express";
+import { OperatorService } from "./operator.service.js";
+
+// Serve next token in queue
+export async function serveNextToken(req: Request, res: Response) {
+  const { queueId } = req.params;
+
+  const result = await OperatorService.serveNextToken(queueId);
+
+  if (!result.success) {
+    return res.status(400).json(result);
+  }
+
+  return res.status(200).json(result);
+}
+
+// Skip current token
+export async function skipCurrentToken(req: Request, res: Response) {
+  const { queueId } = req.params;
+
+  const result = await OperatorService.skipCurrentToken(queueId);
+
+  if (!result.success) {
+    return res.status(400).json(result);
+  }
+
+  return res.status(200).json(result);
+}
+
+// Recall current token
+export async function recallCurrentToken(req: Request, res: Response) {
+  const { queueId } = req.params;
+
+  const result = await OperatorService.recallCurrentToken(queueId);
+
+  if (!result.success) {
+    return res.status(400).json(result);
+  }
+
+  return res.status(200).json(result);
+}
+
+// Pause queue
+export async function pauseQueue(req: Request, res: Response) {
+  const { queueId } = req.params;
+
+  const result = await OperatorService.pauseQueue(queueId);
+
+  if (!result.success) {
+    return res.status(400).json(result);
+  }
+
+  return res.status(200).json(result);
+}
+
+// Resume queue
+export async function resumeQueue(req: Request, res: Response) {
+  const { queueId } = req.params;
+
+  const result = await OperatorService.resumeQueue(queueId);
+
+  if (!result.success) {
+    return res.status(400).json(result);
+  }
+
+  return res.status(200).json(result);
+}

--- a/backend/src/modules/operator/operator.routes.ts
+++ b/backend/src/modules/operator/operator.routes.ts
@@ -1,0 +1,27 @@
+import { Router } from "express";
+import {
+  serveNextToken,
+  skipCurrentToken,
+  recallCurrentToken,
+  pauseQueue,
+  resumeQueue,
+} from "./operator.controller.js";
+
+const router = Router();
+
+// Serve next token
+router.post("/queues/:queueId/serve-next", serveNextToken);
+
+// Skip current token
+router.post("/queues/:queueId/skip", skipCurrentToken);
+
+// Recall current token
+router.post("/queues/:queueId/recall", recallCurrentToken);
+
+// Pause queue
+router.patch("/queues/:queueId/pause", pauseQueue);
+
+// Resume queue
+router.patch("/queues/:queueId/resume", resumeQueue);
+
+export default router;

--- a/backend/src/modules/operator/operator.service.ts
+++ b/backend/src/modules/operator/operator.service.ts
@@ -1,0 +1,203 @@
+import { Queue, Token, TokenStatus } from '../queue/queue.model.js';
+
+export interface OperatorResponse {
+  success: boolean;
+  token?: {
+    id: string;
+    queueId: string;
+    seq: number;
+    status: TokenStatus;
+    createdAt: string;
+  };
+  queue?: {
+    id: string;
+    name: string;
+    isActive: boolean;
+    nextSequence: number;
+  };
+  error?: string;
+}
+
+export class OperatorService {
+  // Serve next token in queue
+  static async serveNextToken(queueId: string): Promise<OperatorResponse> {
+    try {
+      // Find the next waiting token with lowest sequence number
+      console.log(queueId);//debug
+      const nextToken = await Token.findOne({
+        queue: queueId,
+        status: TokenStatus.WAITING
+      }).sort({ seq: 1 });
+
+      console.log(nextToken);//debug
+      if (!nextToken) {
+        return {
+          success: false,
+          error: "No waiting tokens found in queue"
+        };
+      }
+
+      // Update token status to served
+      nextToken.status = TokenStatus.SERVED;
+      await nextToken.save();
+
+      return {
+        success: true,
+        token: {
+          id: nextToken._id.toString(),
+          queueId: nextToken.queue.toString(),
+          seq: nextToken.seq,
+          status: nextToken.status,
+          createdAt: nextToken.createdAt.toISOString(),
+        }
+      };
+    } catch {
+      return {
+        success: false,
+        error: "Failed to serve next token"
+      };
+    }
+  }
+
+  // Skip current token (the one being served)
+  static async skipCurrentToken(queueId: string): Promise<OperatorResponse> {
+    try {
+      // Find the current token (last served token)
+      const currentToken = await Token.findOne({
+        queue: queueId,
+        status: TokenStatus.SERVED
+      }).sort({ seq: -1 });
+
+      if (!currentToken) {
+        return {
+          success: false,
+          error: "No current token to skip"
+        };
+      }
+
+      // Update token status to skipped
+      currentToken.status = TokenStatus.SKIPPED;
+      await currentToken.save();
+
+      return {
+        success: true,
+        token: {
+          id: currentToken._id.toString(),
+          queueId: currentToken.queue.toString(),
+          seq: currentToken.seq,
+          status: currentToken.status,
+          createdAt: currentToken.createdAt.toISOString(),
+        }
+      };
+    } catch {
+      return {
+        success: false,
+        error: "Failed to skip current token"
+      };
+    }
+  }
+
+  // Recall current token (change skipped back to waiting)
+  static async recallCurrentToken(queueId: string): Promise<OperatorResponse> {
+    try {
+      // Find the last skipped token
+      const skippedToken = await Token.findOne({
+        queue: queueId,
+        status: TokenStatus.SKIPPED
+      }).sort({ seq: -1 });
+
+      if (!skippedToken) {
+        return {
+          success: false,
+          error: "No skipped token to recall"
+        };
+      }
+
+      // Update token status back to waiting
+      skippedToken.status = TokenStatus.WAITING;
+      await skippedToken.save();
+
+      return {
+        success: true,
+        token: {
+          id: skippedToken._id.toString(),
+          queueId: skippedToken.queue.toString(),
+          seq: skippedToken.seq,
+          status: skippedToken.status,
+          createdAt: skippedToken.createdAt.toISOString(),
+        }
+      };
+    } catch {
+      return {
+        success: false,
+        error: "Failed to recall token"
+      };
+    }
+  }
+
+  // Pause queue (stop accepting new tokens)
+  static async pauseQueue(queueId: string): Promise<OperatorResponse> {
+    try {
+      const queue = await Queue.findByIdAndUpdate(
+        queueId,
+        { isActive: false },
+        { new: true, runValidators: true }
+      );
+
+      if (!queue) {
+        return {
+          success: false,
+          error: "Queue not found"
+        };
+      }
+
+      return {
+        success: true,
+        queue: {
+          id: queue._id.toString(),
+          name: queue.name,
+          isActive: queue.isActive,
+          nextSequence: queue.nextSequence
+        }
+      };
+    } catch {
+      return {
+        success: false,
+        error: "Failed to pause queue"
+      };
+    }
+  }
+
+  // Resume queue (start accepting new tokens)
+  static async resumeQueue(queueId: string): Promise<OperatorResponse> {
+    try {
+      const queue = await Queue.findByIdAndUpdate(
+        queueId,
+        { isActive: true },
+        { new: true, runValidators: true }
+      );
+
+      if (!queue) {
+        return {
+          success: false,
+          error: "Queue not found"
+        };
+      }
+
+      return {
+        success: true,
+        queue: {
+          id: queue._id.toString(),
+          name: queue.name,
+          isActive: queue.isActive,
+          nextSequence: queue.nextSequence
+        }
+      };
+    } catch {
+      return {
+        success: false,
+        error: "Failed to resume queue"
+      };
+    }
+  }
+}

--- a/backend/src/modules/queue/queue.controller.ts
+++ b/backend/src/modules/queue/queue.controller.ts
@@ -13,13 +13,14 @@ export async function createQueue(req: Request, res: Response) {
         error: "Queue name is required",
       });
     }
-    const exists = await Queue.findOne({name:name});
-    if(exists){
-      return res.status(400).json({
-        success:false,
-        error:"Queue is already there"
-      })
-    }
+    /*----------------NOTE : for now we are not checking if queue already exists or not but if later we need to check then we can add it */
+    // const exists = await Queue.findOne({name:name});
+    // if(exists){
+    //   return res.status(400).json({
+    //     success:false,
+    //     error:"Queue is already there"
+    //   })
+    // }
 
     const queue = await Queue.create({ name });
 


### PR DESCRIPTION
Issue  : #93 

---

##  Video demonstration



https://github.com/user-attachments/assets/f19bcda1-72dc-4c3e-867f-bfd2e40b7524

---

## PR  checklist

Add comprehensive operator APIs for managing live queue flow:
- [x] Serve next token in sequence
- [x]  Skip current serving token  
- [x] Recall skipped tokens back to queue
- [x] Pause/resume queue operations
 
 
APIs:
- POST /api/operator/queues/:queueId/serve-next
- POST /api/operator/queues/:queueId/skip
- POST /api/operator/queues/:queueId/recall
- PATCH /api/operator/queues/:queueId/pause
- PATCH /api/operator/queues/:queueId/resume
 
Ready for Operator Dashboard UI and WebSocket integration.
---