### PR TITLE
Created dashboard operator page

### DIFF
--- a/frontend/app/(routes)/dashboard/operator/page.tsx
+++ b/frontend/app/(routes)/dashboard/operator/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { mockQueue, mockTokens } from "@/app/components/operator/MockData";
+import NowServingCard from "@/app/components/operator/NowServingCard";
+import OperatorControls from "@/app/components/operator/OperatorControls";
+import OperatorHeader from "@/app/components/operator/OperatorHeader";
+import TokenList from "@/app/components/operator/TokenList";
+import { useState } from "react";
+
+export default function OperatorDashboard() {
+  const [queueStatus, setQueueStatus] = useState(mockQueue.status);
+  const [tokens, setTokens] = useState(mockTokens);
+  const [currentToken, setCurrentToken] = useState<{
+    id: string;
+    number: number;
+    status: string;
+  } | null>(null);
+
+  // Serve next waiting token
+  const serveNext = () => {
+    if (queueStatus === "PAUSED") return;
+
+    const nextToken = tokens.find((token) => token.status === "WAITING");
+
+    if (!nextToken) return;
+
+    setCurrentToken(nextToken);
+
+    setTokens((prev) =>
+      prev.map((token) =>
+        token.id === nextToken.id ? { ...token, status: "SERVED" } : token
+      )
+    );
+  };
+
+  // Skip current token
+  const skipToken = () => {
+    if (!currentToken) return;
+
+    setTokens((prev) =>
+      prev.map((token) =>
+        token.id === currentToken.id ? { ...token, status: "SKIPPED" } : token
+      )
+    );
+
+    setCurrentToken(null);
+  };
+
+  // Recall current token (mock behavior)
+  const recallToken = () => {
+    if (!currentToken) return;
+
+    alert(`Recalling Token ${currentToken.number}`);
+  };
+
+  // Pause / Resume queue
+  const toggleQueueStatus = () => {
+    setQueueStatus((prev) => (prev === "ACTIVE" ? "PAUSED" : "ACTIVE"));
+  };
+
+  // ------------------ UI ------------------
+  return (
+    <div className="p-8 space-y-8 max-w-5xl mx-auto bg-gray-50 min-h-screen">
+      <OperatorHeader queue={mockQueue} status={queueStatus} />
+
+      <NowServingCard token={currentToken} />
+
+      <TokenList tokens={tokens.slice(0, 10)} />
+
+      <OperatorControls
+        onServeNext={serveNext}
+        onSkip={skipToken}
+        onRecall={recallToken}
+        onToggleQueue={toggleQueueStatus}
+        queueStatus={queueStatus}
+      />
+    </div>
+  );
+}

--- a/frontend/app/components/operator/MockData.ts
+++ b/frontend/app/components/operator/MockData.ts
@@ -1,0 +1,15 @@
+export const mockQueue = {
+  id: "queue-1",
+  name: "Admin Office – Block A",
+  location: "Ground Floor",
+  status: "ACTIVE", // ACTIVE | PAUSED
+};
+
+export const mockTokens = [
+  { id: "T101", number: 101, status: "WAITING" },
+  { id: "T102", number: 102, status: "WAITING" },
+  { id: "T103", number: 103, status: "WAITING" },
+  { id: "T104", number: 104, status: "WAITING" },
+  { id: "T105", number: 105, status: "WAITING" },
+  { id: "T106", number: 106, status: "WAITING" },
+];

--- a/frontend/app/components/operator/NowServingCard.tsx
+++ b/frontend/app/components/operator/NowServingCard.tsx
@@ -1,0 +1,15 @@
+type Props = {
+  token: { number: number } | null;
+};
+
+export default function NowServingCard({ token }: Props) {
+  return (
+    <div className="bg-white rounded-xl border shadow-sm p-8 text-center">
+      <p className="text-sm text-gray-500">Now Serving</p>
+
+      <h2 className="text-5xl font-bold mt-3 tracking-wide">
+        {token ? token.number : "--"}
+      </h2>
+    </div>
+  );
+}

--- a/frontend/app/components/operator/OperatorControls.tsx
+++ b/frontend/app/components/operator/OperatorControls.tsx
@@ -1,0 +1,44 @@
+type Props = {
+  onServeNext: () => void;
+  onSkip: () => void;
+  onRecall: () => void;
+  onToggleQueue: () => void;
+  queueStatus: string;
+};
+
+export default function OperatorControls({
+  onServeNext,
+  onSkip,
+  onRecall,
+  onToggleQueue,
+  queueStatus,
+}: Props) {
+  return (
+    <div className="bg-white rounded-xl border shadow-sm p-6">
+      <div className="flex gap-4 flex-wrap">
+        <button onClick={onServeNext} className="btn">
+          Serve Next
+        </button>
+
+        <button onClick={onSkip} className="btn">
+          Skip
+        </button>
+
+        <button onClick={onRecall} className="btn">
+          Recall
+        </button>
+
+        <button
+          onClick={onToggleQueue}
+          className={`btn ${
+            queueStatus === "ACTIVE"
+              ? "bg-red-50 text-red-600"
+              : "bg-green-50 text-green-600"
+          }`}
+        >
+          {queueStatus === "ACTIVE" ? "Pause Queue" : "Resume Queue"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/operator/OperatorHeader.tsx
+++ b/frontend/app/components/operator/OperatorHeader.tsx
@@ -1,0 +1,28 @@
+type Props = {
+  queue: {
+    name: string;
+    location: string;
+  };
+  status: string;
+};
+
+export default function OperatorHeader({ queue, status }: Props) {
+  return (
+    <div className="bg-white rounded-xl border shadow-sm p-6 flex justify-between items-center">
+      <div>
+        <h2 className="text-2xl font-semibold">{queue.name}</h2>
+        <p className="text-sm text-gray-500">{queue.location}</p>
+      </div>
+
+      <span
+        className={`px-4 py-1 rounded-full text-xs font-semibold ${
+          status === "ACTIVE"
+            ? "bg-green-100 text-green-700"
+            : "bg-red-100 text-red-600"
+        }`}
+      >
+        {status}
+      </span>
+    </div>
+  );
+}

--- a/frontend/app/components/operator/TokenList.tsx
+++ b/frontend/app/components/operator/TokenList.tsx
@@ -1,0 +1,30 @@
+type Token = {
+  id: string;
+  number: number;
+  status: string;
+};
+
+export default function TokenList({ tokens }: { tokens: Token[] }) {
+  return (
+    <div className="bg-white rounded-xl border shadow-sm p-6">
+      <h3 className="text-lg font-semibold mb-4">
+        Upcoming Tokens
+      </h3>
+
+      <ul className="space-y-3">
+        {tokens.map((token) => (
+          <li
+            key={token.id}
+            className="flex justify-between items-center text-sm"
+          >
+            <span>Token {token.number}</span>
+
+            <span className="px-3 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-700">
+              {token.status}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,3 +1,8 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+.btn {
+  @apply px-4 py-2 rounded-lg text-sm font-medium border 
+         bg-white hover:bg-gray-100 transition 
+         cursor-pointer shadow-sm;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5815,13 +5815,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5874,7 +5876,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",


### PR DESCRIPTION
 Issue: #92

**Short description of what this resolves:**  
Implements a dedicated **Operator Dashboard UI** for CampusOR using **mock data only**, allowing staff to monitor and control a single queue through clear and instant actions.

**Changes proposed in this pull request and/or Screenshots of changes:**  
- Added `/dashboard/operator` route for operator-specific dashboard  
- Built operator dashboard UI for a single queue using mock queue and token data  
- Displayed queue name, location, current status (Active/Paused), “Now Serving” token, and upcoming tokens (5–10)  
- Implemented mocked operator actions: Serve Next, Skip Token, Recall Token, Pause/Resume Queue  
- Ensured instant UI updates using local state (no page reload)  
- Followed existing CampusOR dashboard design language  
- Attached screenshots of full operator view and screen recording showing serve, skip, and pause/resume actions  
- Explained how mock state maps to future backend/WebSocket events  
<img width="1881" height="880" alt="image" src="https://github.com/user-attachments/assets/8d261144-78fb-4eda-a4ea-4ce7befca5d8" />
<img width="1911" height="896" alt="image" src="https://github.com/user-attachments/assets/8cc74daa-7994-4ab1-994b-d2f89e522ddb" />
<img width="1919" height="886" alt="image" src="https://github.com/user-attachments/assets/bbf1a4bb-b595-4c7c-9f12-cfe5ecd2686d" />
<img width="1912" height="954" alt="image" src="https://github.com/user-attachments/assets/bc1eff94-58b1-4d18-ad69-e552f5ebbd9e" />


https://github.com/user-attachments/assets/a3b1bb36-b00a-40c4-a89c-7c7965caa7b1

